### PR TITLE
Preview to main

### DIFF
--- a/components/neonRoad/Palm.tsx
+++ b/components/neonRoad/Palm.tsx
@@ -4,8 +4,8 @@
 import { forwardRef } from 'react'
 import type { Mesh, Group, MeshStandardMaterial } from 'three'
 import { useGLTF } from '@react-three/drei'
-import { GLTF } from 'three-stdlib'
-import { GroupProps } from '@react-three/fiber'
+import type { GLTF } from 'three-stdlib'
+import type { GroupProps } from '@react-three/fiber'
 
 // types for the gltf version
 type GLTFResult = GLTF & {
@@ -31,7 +31,6 @@ const PALM_GLTF_PATH = '/assets/3d_models/palm/palm.gltf'
 // code for the gltf version
 const PalmModel = forwardRef<Group, GroupProps>((props, ref) => {
     
-    // types problem see: https://github.com/pmndrs/gltfjsx/issues/167
     const { nodes, materials } = useGLTF(PALM_GLTF_PATH) as GLTFResult
 
     return (

--- a/components/neonRoad/Palm.tsx
+++ b/components/neonRoad/Palm.tsx
@@ -31,7 +31,11 @@ const PALM_GLTF_PATH = '/assets/3d_models/palm/palm.gltf'
 // code for the gltf version
 const PalmModel = forwardRef<Group, GroupProps>((props, ref) => {
     
-    const { nodes, materials } = useGLTF(PALM_GLTF_PATH) as GLTFResult
+    // second parameter is false to disable draco (wasm decompression tool)
+    // modern browsers support the CSP directive 'wasm-unsafe-eval'
+    // but older browsers require the 'unsafe-eval' directive
+    // when draco is disabled there is no need for wasm, so also no need for 'unsafe-eval'
+    const { nodes, materials } = useGLTF(PALM_GLTF_PATH, false) as GLTFResult
 
     return (
         <group name={'PalmModel'} {...props} ref={ref}>

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -304,6 +304,9 @@ const securityHeadersConfig = (phase) => {
         // unfortunatly because of fontawesome this is not possible (yet)
         // https://github.com/FortAwesome/Font-Awesome/issues/20001
 
+        // removed 'wasm-unsafe-eval' from script-src
+        // draco compression needed that directive, but it is now disabled (in Palm.tsx)
+
         // when environment is preview enable unsafe-inline scripts for vercel preview feedback/comments feature
         // and whitelist vercel's domains based on:
         // https://vercel.com/docs/workflow-collaboration/comments/specialized-usage#using-a-content-security-policy
@@ -314,7 +317,7 @@ const securityHeadersConfig = (phase) => {
                 ${defaultCSPDirectives}
                 font-src 'self' https://vercel.live/ https://assets.vercel.com https://fonts.gstatic.com;
                 style-src 'self' 'unsafe-inline' https://vercel.live/fonts;
-                script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' https://vercel.live/;
+                script-src 'self' 'unsafe-inline' https://vercel.live/;
                 connect-src 'self' https://vercel.live/ https://vitals.vercel-insights.com https://*.pusher.com/ wss://*.pusher.com/ ${reportingDomainWildcard};
                 img-src 'self' data: https://vercel.com/ https://vercel.live/;
                 frame-src 'self' https://vercel.live/;
@@ -329,7 +332,7 @@ const securityHeadersConfig = (phase) => {
                 ${defaultCSPDirectives}
                 font-src 'self';
                 style-src 'self' 'unsafe-inline';
-                script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval';
+                script-src 'self' 'unsafe-inline';
                 connect-src 'self' https://vitals.vercel-insights.com ${reportingDomainWildcard};
                 img-src 'self' data:;
                 frame-src 'none';


### PR DESCRIPTION
* small update of the palm script
* disable draco compression for the gltf loader, as draco uses wasm, which in older browser require the unsafe-eval directive for the script-src CSP (modern browsers support a new directive wasm-unsafe-eval)